### PR TITLE
Fix issue when canceling with C-g

### DIFF
--- a/avy-zap.el
+++ b/avy-zap.el
@@ -153,6 +153,9 @@
 (defvar avy-zap-function 'kill-region
   "The function used for zapping to char.")
 
+(defconst avy-zap--function-list '(kill-region delete-region)
+  "List of valid `avy-zap-function' values.")
+
 (defvar avy-zap-dwim-prefer-avy t
   "Whether the default dwim behavior of `avy-zap' should use `avy' or not.")
 
@@ -182,14 +185,13 @@ Otherwise, don't rebind."
     (avy-zap--flet-if
         avy-zap-forward-only
         (window-start (&optional window) (point))
-      (if (or (equal avy-zap-function #'kill-region)
-              (equal avy-zap-function #'delete-region))
-	  (when (and (call-interactively 'avy-goto-char)
-		     (avy-zap--xor (<= start (point)) zap-up-to-char-p))
-            (forward-char))
-	(funcall avy-zap-function start (point)))
-        (error "Unknown value for `avy-zap-function'!\
- Please choose between `kill-region' and `delete-region'"))))
+      (if (member avy-zap-function avy-zap--function-list)
+	  (when (call-interactively 'avy-goto-char)
+	    (and (avy-zap--xor (<= start (point)) zap-up-to-char-p)
+		 (forward-char))
+	    (funcall avy-zap-function start (point)))
+        (error "Invalid `avy-zap-function' value `%s' is not in the valid list: %s"
+	       avy-zap-function avy-zap--function-list)))))
 
 ;;;###autoload
 (defun avy-zap-to-char ()

--- a/avy-zap.el
+++ b/avy-zap.el
@@ -184,13 +184,12 @@ Otherwise, don't rebind."
         (window-start (&optional window) (point))
       (if (or (equal avy-zap-function #'kill-region)
               (equal avy-zap-function #'delete-region))
-	  (progn
-            (call-interactively 'avy-goto-char)
-	    (when (avy-zap--xor (<= start (point)) zap-up-to-char-p)
-              (forward-char))
-	    (funcall avy-zap-function start (point)))
+	  (when (and (call-interactively 'avy-goto-char)
+		     (avy-zap--xor (<= start (point)) zap-up-to-char-p))
+            (forward-char))
+	(funcall avy-zap-function start (point)))
         (error "Unknown value for `avy-zap-function'!\
- Please choose between `kill-region' and `delete-region'")))))
+ Please choose between `kill-region' and `delete-region'"))))
 
 ;;;###autoload
 (defun avy-zap-to-char ()


### PR DESCRIPTION
(call-interactively 'avy-goto-char) returns nil when canceled with
C-g.

It needs to be checked to go forward otherwise at least one
char is be always deleted when cancelling with C-g.